### PR TITLE
Add delete fact functionality

### DIFF
--- a/components/Fact.vue
+++ b/components/Fact.vue
@@ -24,6 +24,14 @@
                     <Icon name="mdi:thumb-down" />
                     <span>{{ fact.downvotes }}</span>
                 </button>
+                <button
+                    v-if="isOwner"
+                    @click="handleDelete"
+                    class="action-btn delete"
+                    data-umami-event="delete-fact"
+                >
+                    <Icon name="mdi:delete" />
+                </button>
             </div>
             <time :datetime="fact.created_at">{{
                 formatDate(fact.created_at)
@@ -33,8 +41,9 @@
 </template>
 
 <script setup>
-import { ref } from "vue";
+import { ref, computed } from "vue";
 import { useVoting } from "../composables/useVoting";
+import { useAuth } from "../composables/useAuth";
 
 const props = defineProps({
     fact: {
@@ -45,6 +54,8 @@ const props = defineProps({
 
 const fact = ref(props.fact);
 const { hasVoted, isVoting, handleVote } = useVoting(fact.value.id);
+const auth = useAuth();
+const isOwner = computed(() => auth.state.user?.id === fact.value.user_id);
 
 async function vote(voteType) {
     try {
@@ -64,6 +75,10 @@ function formatDate(dateString) {
         ),
         "day",
     );
+}
+
+function handleDelete() {
+    emit("delete-fact", fact.value.id);
 }
 </script>
 
@@ -123,6 +138,16 @@ function formatDate(dateString) {
 }
 
 .action-btn.downvote.active {
+    color: #e74c3c;
+}
+
+/* Delete button styles */
+.action-btn.delete {
+    color: #e74c3c;
+}
+
+.action-btn.delete:hover {
+    background-color: #f0f0f0;
     color: #e74c3c;
 }
 

--- a/composables/useFacts.ts
+++ b/composables/useFacts.ts
@@ -56,9 +56,27 @@ export const useFacts = () => {
     });
   };
 
+  const deleteFact = async (factId: number) => {
+    const headers: Record<string, string> = {};
+
+    if (import.meta.client) {
+      const token = localStorage.getItem("auth_token");
+      if (!token) {
+        throw new Error("Authentication required to delete a fact");
+      }
+      headers["Authorization"] = `Bearer ${token}`;
+    }
+
+    return fetchWithError(`${baseURL}/facts/${factId}/delete`, {
+      headers,
+      method: "POST",
+    });
+  };
+
   return {
     getAllFacts,
     getRandomFact,
     createFact,
+    deleteFact,
   };
 };

--- a/pages/profile.vue
+++ b/pages/profile.vue
@@ -92,7 +92,7 @@
                 <div v-if="userFacts.length === 0" class="no-facts">
                     You haven't shared any facts yet.
                 </div>
-                <FactsList v-else :facts="userFacts" />
+                <FactsList v-else :facts="userFacts" @delete-fact="onFactDeleted" />
             </div>
         </div>
     </div>
@@ -101,8 +101,10 @@
 <script setup>
 import { ref, onMounted } from "vue";
 import { useAuth } from "~/composables/useAuth";
+import { useFacts } from "~/composables/useFacts";
 
 const auth = useAuth();
+const { deleteFact } = useFacts();
 const activeTab = ref("stats");
 const isAddingFact = ref(false);
 
@@ -123,6 +125,17 @@ const onFactAdded = (newFact) => {
     isAddingFact.value = false;
     // Update stats
     stats.value.factsCreated++;
+};
+
+const onFactDeleted = async (factId) => {
+    try {
+        await deleteFact(factId);
+        userFacts.value = userFacts.value.filter(fact => fact.id !== factId);
+        // Update stats
+        stats.value.factsCreated--;
+    } catch (error) {
+        console.error("Error deleting fact:", error);
+    }
 };
 
 onMounted(async () => {

--- a/server/api/facts/[id]/delete.post.ts
+++ b/server/api/facts/[id]/delete.post.ts
@@ -1,0 +1,54 @@
+import jwt from "jsonwebtoken";
+import pool from "~/server/db";
+import { JWT_SECRET } from "~/server/utils/auth";
+
+export default defineEventHandler(async (event) => {
+  try {
+    // Authenticate the user
+    const authHeader = getHeader(event, "Authorization");
+    if (!authHeader?.startsWith("Bearer ")) {
+      throw createError({
+        statusCode: 401,
+        message: "Authentication required",
+      });
+    }
+
+    const token = authHeader.split(" ")[1];
+    const decoded = jwt.verify(token, JWT_SECRET) as { userId: number };
+    const userId = decoded.userId;
+
+    const factId = event.context.params.id;
+
+    // Verify the user owns the fact
+    const factResult = await pool.query(
+      "SELECT user_id FROM facts WHERE id = $1",
+      [factId]
+    );
+
+    if (factResult.rows.length === 0) {
+      throw createError({
+        statusCode: 404,
+        message: "Fact not found",
+      });
+    }
+
+    const fact = factResult.rows[0];
+    if (fact.user_id !== userId) {
+      throw createError({
+        statusCode: 403,
+        message: "You do not have permission to delete this fact",
+      });
+    }
+
+    // Delete the fact
+    await pool.query("DELETE FROM facts WHERE id = $1", [factId]);
+
+    return { message: "Fact deleted successfully" };
+  } catch (error: any) {
+    console.error("Error deleting fact:", error);
+    throw createError({
+      statusCode: error.statusCode || 500,
+      message: error.message || "Error deleting fact",
+    });
+  }
+});


### PR DESCRIPTION
Add functionality for users to delete their own facts.

* **UI Changes**:
  - Add a delete button in `components/Fact.vue` for users to delete their own facts.
  - Emit a `delete-fact` event when the delete button is clicked.
  - Add a method to handle the delete button click and emit the event.

* **API Changes**:
  - Create a new API endpoint in `server/api/facts/[id]/delete.post.ts` to handle fact deletion.
  - Authenticate the user and verify they own the fact before deleting.
  - Return a success message or error if the deletion fails.

* **Composables**:
  - Add a `deleteFact` function in `composables/useFacts.ts` to call the new delete API endpoint.

* **Profile Page**:
  - Update `pages/profile.vue` to handle the `delete-fact` event and call `deleteFact`.
  - Remove the deleted fact from the `userFacts` array.
